### PR TITLE
fixed a bug kobo_audit_ caused by a clash when either `old-value` or …

### DIFF
--- a/R/kobo_audit.R
+++ b/R/kobo_audit.R
@@ -43,6 +43,11 @@ kobo_audit_ <- function(uid, progress = FALSE) {
                                                  colClasses = col_classes,
                                                  data.table = FALSE)))
   res <- select(res, -"download_url")
+  res$data <- lapply(res$data, function(x) {
+    x[['old-value']] <- as.character(x[['old-value']])
+    x[['new-value']] <- as.character(x[['new-value']])
+    x
+  })
   unnest(res, "data") |>
     mutate(name = basename(.data$node), .before = "start",
            start_int = .data$start,


### PR DESCRIPTION
Hello, please accept the pull request. I was using this package to load a large dataframe of audits and encountered a bug caused by a clash when either `old-value` or `new-value` column in audits only has a single numeric value. This breaks the script when calling the unnest(res, "data") function. I've applied a function that transforms these into characters.